### PR TITLE
[Feature #162879502] built and tested get-all-entries endpoint

### DIFF
--- a/controllers/diaryController.js
+++ b/controllers/diaryController.js
@@ -1,5 +1,12 @@
 import diaryList from '../models/diaryModel';
 
-class DiaryController {}
+class DiaryController {
+  static getAll(req, res) {
+    res.status(200).json({
+      diaryList,
+      message: 'Diary entries successfully retrieved',
+    });
+  }
+}
 
 export default DiaryController;

--- a/routes/diaryRoute.js
+++ b/routes/diaryRoute.js
@@ -1,3 +1,6 @@
 import diaryController from '../controllers/diaryController';
 
-export default (router) => {};
+export default (router) => {
+  router.route('/v1/entries')
+    .get(diaryController.getAll);
+};

--- a/tests/diaryTest.js
+++ b/tests/diaryTest.js
@@ -5,3 +5,15 @@ import chaiHttp from 'chai-http';
 import app from '../index';
 
 chai.use(chaiHttp);
+
+describe("Test diary endpoint at '/v1/entries' to get all entries with GET", () => {
+  it("should get all diary entries at '/v1/entries' with GET", (done) => {
+    chai.request(app)
+      .get('/v1/entries')
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).be.an('object');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What does this PR do ?**
Have a get-all-entries endpoint in Express JS REST API

**Description of task completed ?**
Have the below endpoint working
`GET /v1/entries`

**How to manually test this ?**
Clone repo, checkout to branch `ft-get-all-entries-#162879502` and either run npm test or start the server with `npm start` and use POSTMAN to test via `GET` at `localhost:3000/v1/entries`

**Relevant Pivotal stories ?**
#162879502