### PR TITLE
[Feature #162898194] Built and tested create-one-entry endpoint

### DIFF
--- a/controllers/diaryController.js
+++ b/controllers/diaryController.js
@@ -1,5 +1,28 @@
 import diaryList from '../models/diaryModel';
 
-class DiaryController {}
+class DiaryController {
+  static createOne(req, res) {
+    if (!req.body.title) {
+      res.status(400).json({
+        message: 'Title is required',
+      });
+    } else if (!req.body.description) {
+      res.status(400).json({
+        message: 'Description is required',
+      });
+    } else {
+      const diaryEntry = {
+        id: diaryList.length,
+        title: req.body.title,
+        description: req.body.description,
+      };
+      diaryList.push(diaryEntry);
+      res.status(201).json({
+        message: 'Diary Entry successfully created',
+        diaryEntry,
+      });
+    }
+  }
+}
 
 export default DiaryController;

--- a/routes/diaryRoute.js
+++ b/routes/diaryRoute.js
@@ -1,3 +1,6 @@
 import diaryController from '../controllers/diaryController';
 
-export default (router) => {};
+export default (router) => {
+  router.route('/v1/entries')
+    .post(diaryController.createOne);
+};

--- a/tests/diaryTest.js
+++ b/tests/diaryTest.js
@@ -5,3 +5,48 @@ import chaiHttp from 'chai-http';
 import app from '../index';
 
 chai.use(chaiHttp);
+
+describe("Test diary endpoint at '/v1/entries' to create a new entry with POST", () => {
+  it("should create a diary entry at '/v1/entries' with POST", (done) => {
+    chai.request(app)
+      .post('/v1/entries')
+      .send({
+        title: 'dinner',
+        description: 'alone',
+      })
+      .then((res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).be.an('object');
+        expect(res.body.diaryEntry).to.have.property('id');
+        expect(res.body.diaryEntry).to.have.property('title');
+        expect(res.body.diaryEntry).to.have.property('description');
+        done();
+      });
+  });
+
+  it("it should NOT create a diary entry at '/v1/entries' if title is null or undefined with POST", (done) => {
+    chai.request(app)
+      .post('/v1/entries')
+      .send({
+        description: 'lorem',
+      })
+      .then((res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property('message').equal('Title is required');
+        done();
+      });
+  });
+
+  it("it should NOT create a diary entry at '/v1/entries' if description is null or undefined with POST", (done) => {
+    chai.request(app)
+      .post('/v1/entries')
+      .send({
+        title: 'lorem',
+      })
+      .then((res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property('message').equal('Description is required');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What this PR does ?**
Have an endpoint to create one diary entry using ExpressJS

**Description of task completed ?**
Have the below working endpoint
`POST /v1/entries`

**How to manually test this ?**
Clone repo, checkout to branch ft-create-one-entry-#162898194 then RUN `npm test` or RUN `npm start` to start server and test with POSTMAN via POST at `localhost:3000/v1/entries`

**Relevant Pivotal Stories ?**
#162898194