### PR TITLE
[Feature #162883631] Built and tested delete-one-entry endpoint

### DIFF
--- a/controllers/diaryController.js
+++ b/controllers/diaryController.js
@@ -1,5 +1,20 @@
 import diaryList from '../models/diaryModel';
 
-class DiaryController {}
+class DiaryController {
+  static deleteOne(req, res) {
+    const id = parseInt(req.params.id, 10);
+    const diaryEntry = diaryList.find(diaryItem => diaryItem.id === id);
+    if (!diaryEntry) {
+      res.status(404).json({
+        message: 'Diary entry does not exist',
+      });
+    } else {
+      diaryList.splice(diaryEntry.id, 1);
+      res.status(200).json({
+        message: 'Diary entry successfully deleted',
+      });
+    }
+  }
+}
 
 export default DiaryController;

--- a/routes/diaryRoute.js
+++ b/routes/diaryRoute.js
@@ -1,3 +1,6 @@
 import diaryController from '../controllers/diaryController';
 
-export default (router) => {};
+export default (router) => {
+  router.route('/v1/entries/:id')
+    .delete(diaryController.deleteOne);
+};

--- a/tests/diaryTest.js
+++ b/tests/diaryTest.js
@@ -5,3 +5,28 @@ import chaiHttp from 'chai-http';
 import app from '../index';
 
 chai.use(chaiHttp);
+
+describe("Test endpoint at '/v1/entries/:id to delete a diary entry with DELETE", () => {
+  it("it should delete a diary entry at '/v1/entries/:id' with DELETE if id exists", (done) => {
+    const id = 0;
+    chai.request(app)
+      .del(`/v1/entries/${id}`)
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('message').equal('Diary entry successfully deleted');
+        done();
+      });
+  });
+
+  it("should NOT delete a diary entry at '/v1/entries/:id' with DELETE if id does not exist", (done) => {
+    const id = 10;
+    chai.request(app)
+      .del(`/v1/entries/${id}`)
+      .then((res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.property('message').equal('Diary entry does not exist');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What this PR does ?**
Have an endpoint to delete a diary entry using Express JS

**Description of task completed ? **
Built the below working endpoint:
`DELETE /v1/entries/:id`

**How to test this endpoint ?**
Clone repo, checkout to branch `ft-delete-one-entry-#162883631` then RUN `npm test` or RUN `npm start` and use POSTMAN to test endpoint at `localhost:3000/v1/entries/id` via `DELETE`

**Relevant Pivotal story**
#162883631