### PR TITLE
#162879834 Built and tested and endpoint that gets a diary endpoint

### DIFF
--- a/controllers/getOne.js
+++ b/controllers/getOne.js
@@ -1,5 +1,18 @@
 import diaries from '../models/diaries';
 
-function getOneDiaryEntry() {}
+function getOneDiaryEntry(req, res) {
+  const id = parseInt(req.params.id, 10);
+  const diaryEntry = diaries.find(diaryItem => diaryItem.id === id);
+  if (diaryEntry) {
+    res.status(200).send({
+      message: 'Diary entry successfully retrieved',
+      diaryEntry,
+    });
+  } else {
+    res.status(404).send({
+      message: 'Diary entry does not exist',
+    });
+  }
+}
 
 export default getOneDiaryEntry;

--- a/models/diaries.js
+++ b/models/diaries.js
@@ -1,6 +1,6 @@
 const diaries = [{
   id: 0,
-  titile: 'Title',
+  title: 'Title',
   description: 'Description',
 }];
 

--- a/tests/getOne.js
+++ b/tests/getOne.js
@@ -1,0 +1,35 @@
+import {
+  chai,
+  chaiHttp,
+  expect,
+  app,
+} from './index';
+
+chai.use(chaiHttp);
+
+describe("Test diary endpoint at '/v1/entries/:id' to get one entry with GET", () => {
+  it("should get a diary entry at '/v1/entries/:id' with GET if id exists", (done) => {
+    const id = 0;
+    chai.request(app)
+      .get(`/v1/entries/${id}`)
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).be.an('object');
+        expect(res.body.diaryEntry).to.have.property('id').equal(0);
+        expect(res.body.diaryEntry).to.have.property('title').equal('Title');
+        expect(res.body.diaryEntry).to.have.property('description').equal('Description');
+        done();
+      });
+  });
+
+  it("should NOT get a diary entry at '/v1/entries/:id' with GET if id does not exist", (done) => {
+    const id = 10;
+    chai.request(app)
+      .get(`/v1/entries/${id}`)
+      .then((res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.property('message').equal('Diary entry does not exist');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What this PR does** ?
Have an endpoint gets a diary entry using an id

**Description of task completed ?**
Build the below working endpoint
`GET /v1/entries/:id`

**How to test this ?**
Clone repo, cd into it, checkout to branch `ft-get-one-entry-#162879834` then RUN `npm test` or RUN `npm start` and use POSTMAN to test endpoint at `localhost:3000/v1/entries/:id` via `GET`

Relevant Pivotal story
#162879834